### PR TITLE
feat: add open_access variable to control pipeline access in organiza…

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -23,6 +23,7 @@ locals {
       name        = var.version_control_system_organization_name
       projects    = tolist(var.version_control_system_project_names)
       parallelism = var.maximum_concurrency
+      open_access = var.open_access
     }]
     permission_profile = {
       kind   = "CreatorOnly"
@@ -54,6 +55,7 @@ locals {
       url         = "https://dev.azure.com/${org.name}"
       projects    = org.projects
       parallelism = org.parallelism != null ? org.parallelism : var.maximum_concurrency
+      open_access = org.open_access != null ? org.open_access : false
     }]
     permission_profile = {
       kind   = local.organization_profile_input.permission_profile.kind # "CreatorOnly", "Inherit", "SpecificAccounts"

--- a/variables.tf
+++ b/variables.tf
@@ -404,13 +404,25 @@ variable "maximum_concurrency" {
   }
 }
 
+variable "open_access" {
+  type = bool
+  default = false
+  description = <<DESCRIPTION
+This variable controls whether or not access is open for all pipelines within a project.
+For more information see <https://learn.microsoft.com/en-us/azure/devops/managed-devops-pools/configure-security?view=azure-devops&tabs=azure-portal%2Cwindows#configure-open-access-for-pipelines-to-your-pool>
+If set to false, then specific pipelines must be individually authorized to run on the pool.  This method is the default.
+DESCRIPTION
+ nullable = false
+}
+
 variable "organization_profile" {
   type = object({
     kind = optional(string, "AzureDevOps")
     organizations = list(object({
       name        = string
       projects    = optional(list(string), []) # List of all Projects names this agent should run on, if empty, it will run on all projects.
-      parallelism = optional(number)           # If multiple organizations are specified, this value needs to be set, otherwise it will use the maximum_concurrency value.
+      parallelism = optional(number),          # If multiple organizations are specified, this value needs to be set, otherwise it will use the maximum_concurrency value.
+      open_access = optional(bool, false)      # If set to true, the agent pool will have open access for all pipelines within a project. 
     }))
     permission_profile = optional(object({
       kind   = optional(string, "CreatorOnly")
@@ -432,6 +444,7 @@ If not suppled, then `version_control_system_organization_name` and optionally `
   - `name` - (Required) The name of the organization, without the `https://dev.azure.com/` prefix.
   - `projects` - (Optional) A list of project names this agent should run on. If empty, it will run on all projects. Defaults to `[]`.
   - `parallelism` - (Optional) The parallelism value. If multiple organizations are specified, this value needs to be set and cannot exceed the total value of `maximum_concurrency`; otherwise, it will use the `maximum_concurrency` value as default or the value you define for single Organization.
+  - `open_access` - (Optional) If set to false, then specific pipelines must be individually authorized to run on the pool.  This method is the default.
 - `permission_profile` - (Required) An object representing the permission profile.
   - `kind` - (Required) The kind of permission profile, possible values are `CreatorOnly`, `Inherit`, and `SpecificAccounts`, if `SpecificAccounts` is chosen, you must provide a list of users and/or groups.
   - `users` - (Optional) A list of users for the permission profile, supported value is the `ObjectID` or `UserPrincipalName`. Defaults to `null`.


### PR DESCRIPTION
…tion profile

## Description

Adds "open_access" property to the Azure DevOps organization profile to allow users to specify whether a Managed DevOps Pool is available to all pipelines within a project by default.

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [ x] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [x ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [ x] I'm sure there are no other open Pull Requests for the same update/change
- [ x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks
