### PR TITLE
docs: fix typo in variable description

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,8 +304,8 @@ Default: `{}`
 
 ### <a name="input_enable_telemetry"></a> [enable\_telemetry](#input\_enable\_telemetry)
 
-Description: This variable controls whether or not telemetry is enabled for the module.  
-For more information see <https://aka.ms/avm/telemetryinfo>.  
+Description: This variable controls whether or not telemetry is enabled for the module.
+For more information see <https://aka.ms/avm/telemetryinfo>.
 If it is set to false, then no telemetry will be collected.
 
 Type: `bool`
@@ -484,7 +484,7 @@ Description: An object representing the configuration for an organization profil
 
 This is for advanced use cases where you need to specify permissions and multiple organization.
 
-If not suppled, then `version_control_system_organization_name` and optionally `version_control_system_project_names` must be supplied.
+If not supplied, then `version_control_system_organization_name` and optionally `version_control_system_project_names` must be supplied.
 
 - `organizations` - (Required) A list of objects representing the organizations.
   - `name` - (Required) The name of the organization, without the `https://dev.azure.com/` prefix.

--- a/variables.tf
+++ b/variables.tf
@@ -426,7 +426,7 @@ An object representing the configuration for an organization profile, including 
 
 This is for advanced use cases where you need to specify permissions and multiple organization.
 
-If not suppled, then `version_control_system_organization_name` and optionally `version_control_system_project_names` must be supplied.
+If not supplied, then `version_control_system_organization_name` and optionally `version_control_system_project_names` must be supplied.
 
 - `organizations` - (Required) A list of objects representing the organizations.
   - `name` - (Required) The name of the organization, without the `https://dev.azure.com/` prefix.


### PR DESCRIPTION
## Description

Fix typo in documentation (README and variable description)

## Type of Change

- [x] Non-module change (e.g. CI/CD, documentation, etc.)
- [ ] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [x] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

